### PR TITLE
Tiling canvas overlays

### DIFF
--- a/src/napari/_vispy/_tests/test_canvas.py
+++ b/src/napari/_vispy/_tests/test_canvas.py
@@ -7,9 +7,9 @@ from napari.components.overlays import (
 )
 
 
-def test_viewer_overlays(make_napari_viewer):
-    viewer = make_napari_viewer()
-    canvas = viewer.window._qt_viewer.canvas
+def test_viewer_overlays(qt_viewer):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
 
     for overlay in viewer._overlays.values():
         if isinstance(overlay, CanvasOverlay):
@@ -43,9 +43,9 @@ def test_viewer_overlays(make_napari_viewer):
     assert new_overlay_node not in canvas.view.children
 
 
-def test_layer_overlays(make_napari_viewer):
-    viewer = make_napari_viewer()
-    canvas = viewer.window._qt_viewer.canvas
+def test_layer_overlays(qt_viewer):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
 
     view_children = len(canvas.view.children)
     scene_children = len(canvas.view.scene.children)
@@ -94,10 +94,11 @@ def test_layer_overlays(make_napari_viewer):
     assert len(canvas.view.scene.children) == scene_children
 
 
-def test_grid_mode(make_napari_viewer):
-    viewer = make_napari_viewer(ndisplay=3)
-    canvas = viewer.window._qt_viewer.canvas
+def test_grid_mode(qt_viewer):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
 
+    viewer.dims.ndisplay = 3
     viewer.add_image(np.ones((10, 10, 10)))
 
     angles = 10, 20, 30  # just some nonzero stuff
@@ -127,3 +128,68 @@ def test_grid_mode(make_napari_viewer):
     for camera in (canvas.camera, *canvas.grid_cameras):
         np.testing.assert_allclose(camera.angles, angles)
         assert camera.zoom == zoom
+
+
+def test_tiling_canvas_overlays(qt_viewer):
+    viewer = qt_viewer.viewer
+    canvas = qt_viewer.canvas
+
+    viewer.scale_bar.visible = True
+    viewer.text_overlay.visible = True
+    viewer.text_overlay.text = 'test'
+
+    vispy_scale_bar = canvas._overlay_to_visual[viewer.scale_bar][0]
+    vispy_text_overlay = canvas._overlay_to_visual[viewer.text_overlay][0]
+
+    padding = 10.0  # currently hardcoded
+    y_max, x_max = canvas.size
+
+    scale_bar_y_size = vispy_scale_bar.y_size + padding
+    scale_bar_x_size = vispy_scale_bar.x_size + padding
+
+    text_overlay_y_size = vispy_text_overlay.y_size + padding
+    text_overlay_x_size = vispy_text_overlay.x_size + padding
+
+    # check vertical tiling works on the bottom right
+    viewer.scale_bar.position = 'bottom_right'
+    viewer.text_overlay.position = 'bottom_right'
+    canvas._update_overlay_canvas_positions()
+
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[0],
+        x_max - text_overlay_x_size,
+        decimal=3,
+    )
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[1],
+        y_max - text_overlay_y_size - scale_bar_y_size,
+        decimal=3,
+    )
+
+    # move scale bar out of the way and check tiling is updated
+    viewer.scale_bar.position = 'top_right'
+    canvas._update_overlay_canvas_positions()
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[0],
+        x_max - text_overlay_x_size,
+        decimal=3,
+    )
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[1],
+        y_max - text_overlay_y_size,
+        decimal=3,
+    )
+
+    # check horizontal tiling works on the top right
+    viewer.text_overlay.position = 'top_right'
+    canvas._update_overlay_canvas_positions()
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[0],
+        x_max - text_overlay_x_size - scale_bar_x_size,
+        decimal=3,
+    )
+    np.testing.assert_almost_equal(
+        vispy_text_overlay.node.transform.translate[1],
+        0 + padding,
+        decimal=3,
+    )

--- a/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
+++ b/src/napari/_vispy/_tests/test_vispy_scale_bar_visual.py
@@ -1,5 +1,3 @@
-from unittest.mock import MagicMock
-
 from napari._vispy.overlays.scale_bar import VispyScaleBarOverlay
 from napari.components.overlays import ScaleBarOverlay
 
@@ -11,58 +9,3 @@ def test_scale_bar_instantiation(make_napari_viewer):
     assert vispy_scale_bar.overlay.length is None
     model.length = 50
     assert vispy_scale_bar.overlay.length == 50
-
-
-def test_scale_bar_positioning(make_napari_viewer):
-    viewer = make_napari_viewer()
-    # set devicePixelRatio to 2 so testing works on CI and local
-    viewer.window._qt_window.devicePixelRatio = MagicMock(return_value=2)
-    model = ScaleBarOverlay()
-    scale_bar = VispyScaleBarOverlay(overlay=model, viewer=viewer)
-
-    assert model.position == 'bottom_right'
-    assert model.font_size == 10
-    assert scale_bar.node.box.height == 36
-    assert scale_bar.y_offset == 7
-
-    model.position = 'top_right'
-    # y_offset should be increase to account for box height
-    assert scale_bar.y_offset == 7 + scale_bar.node.box.height / 2
-
-    # increasing font while at top increases y_offset due to new box height
-    model.font_size = 30
-    assert scale_bar.node.box.height == 63
-    assert scale_bar.y_size == 63 / 2
-    assert scale_bar.y_offset == 7 + scale_bar.y_size
-
-    # moving scale bar back to bottom should reset y_offset to 7
-    # y_size and box height should remain the same
-    model.position = 'bottom_right'
-    assert scale_bar.y_offset == 7
-    assert scale_bar.node.box.height == 63
-    assert scale_bar.y_size == 63 / 2
-
-    # changing font_size at bottom should have no effect on the offset
-    # but should increase the box height and y_size
-    model.font_size = 40
-    assert scale_bar.y_offset == 7
-    assert scale_bar.y_size == 38
-    assert scale_bar.node.box.height == 76
-
-    # setting `colored` should have no effect
-    model.colored = True
-    assert scale_bar.y_offset == 7
-    assert scale_bar.y_size == 38
-    assert scale_bar.node.box.height == 76
-    # check that the line is not at the center,
-    # but offset down due to the font size (40)
-    assert scale_bar.node.line.pos[0, 1] == scale_bar.node.box.height / 2 - 18
-
-    # changing `ticks` should have no effect
-    model.ticks = False
-    assert scale_bar.y_offset == 7
-    assert scale_bar.y_size == 38
-    assert scale_bar.node.box.height == 76
-    # check that the line is not at the center,
-    # but offset down due to the font size (40)
-    assert scale_bar.node.line.pos[0, 1] == scale_bar.node.box.height / 2 - 18

--- a/src/napari/_vispy/canvas.py
+++ b/src/napari/_vispy/canvas.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import gc
+from collections.abc import Iterator
 from functools import partial
 from typing import TYPE_CHECKING
 from weakref import WeakSet
@@ -99,6 +100,8 @@ class VispyCanvas:
         was applied.
     _overlay_to_visual : dict(napari.components.overlays, list(napari._vispy.overlays))
         A mapping of the napari overlays that are part of the viewer and their corresponding Vispy counterparts.
+        The values are lists that may contain multiple elements when grid mode is enabled and overlay.gridded == True,
+        associating multiple vispy visual to a single overlay model.
     _layer_overlay_to_visual : dict(napari.layers.Layer, dict(napari.components.overlays, napari._vispy.overlays))
         A mapping from each layer in the layerlist to their mappings of napari overlay->vispy counterpart.
     _scene_canvas : napari._vispy.canvas.NapariSceneCanvas
@@ -137,7 +140,7 @@ class VispyCanvas:
         self.grid_views = []
         self.grid_cameras = []
 
-        self.layer_to_visual: dict[Layer, VispyBaseLayer] = {}
+        self.layer_to_visual: dict[Layer, VispyBaseLayer[Layer]] = {}
         self._overlay_to_visual: dict[Overlay, list[VispyBaseOverlay]] = {}
         self._layer_overlay_to_visual: dict[
             Layer, dict[Overlay, VispyBaseOverlay]
@@ -147,6 +150,7 @@ class VispyCanvas:
 
         self._overlay_callbacks = {}
         self._last_viewbox_size = np.array((0, 0))
+        self._needs_overlay_position_update = False
 
         self.bgcolor = transform_color(
             get_theme(self.viewer.theme).canvas.as_hex()
@@ -234,7 +238,7 @@ class VispyCanvas:
         return self._scene_canvas._backend.screen_changed
 
     @property
-    def background_color_override(self) -> str | None:
+    def background_color_override(self) -> str | npt.ArrayLike | None:
         """Background color of VispyCanvas.
 
         When not None, color is shown instead of VispyCanvas.bgcolor.
@@ -611,7 +615,7 @@ class VispyCanvas:
         bottom_right = self._map_canvas2world(view.rect.size, view)
         return np.array([top_left, bottom_right])
 
-    def on_draw(self, event: DrawEvent) -> None:
+    def on_draw(self, event: DrawEvent | None = None) -> None:
         """Called whenever the canvas is drawn.
 
         This is triggered from vispy whenever new data is sent to the canvas or
@@ -632,8 +636,12 @@ class VispyCanvas:
             self._last_viewbox_size, self._current_viewbox_size
         ):
             self._update_grid_spacing()
-            self._update_overlay_canvas_positions()
             self._last_viewbox_size = self._current_viewbox_size
+            self._needs_overlay_position_update = True
+
+        if self._needs_overlay_position_update:
+            self._update_overlay_canvas_positions()
+            self._needs_overlay_position_update = False
 
         # sync all cameras
         for camera in (self.camera, *self.grid_cameras):
@@ -673,8 +681,6 @@ class VispyCanvas:
         None
         """
         self.viewer._canvas_size = self.size
-        if self.viewer.grid.enabled:
-            self._update_grid_spacing()
 
     def add_layer_visual_mapping(
         self, napari_layer: Layer, vispy_layer: VispyBaseLayer
@@ -788,20 +794,40 @@ class VispyCanvas:
                 vispy_layer.first_visible = False
             vispy_layer._on_blending_change()
 
+        self._defer_overlay_position_update()
+
         self._scene_canvas._draw_order.clear()
         self._scene_canvas.update()
+
+    def _defer_overlay_position_update(self):
+        self._needs_overlay_position_update = True
+
+    def _connect_canvas_overlay_events(self, overlay: Overlay) -> None:
+        overlay.events.position.connect(self._defer_overlay_position_update)
+        overlay.events.visible.connect(self._defer_overlay_position_update)
+
+    def _disconnect_canvas_overlay_events(self, overlay: Overlay) -> None:
+        overlay.events.position.disconnect(self._defer_overlay_position_update)
+        overlay.events.visible.disconnect(self._defer_overlay_position_update)
 
     def _add_viewer_overlay(self, overlay: Overlay, parent: Node) -> None:
         """Create vispy overlay and add to dictionary of overlay visuals"""
         vispy_overlay = create_vispy_overlay(
             overlay=overlay, viewer=self.viewer, parent=parent
         )
+        if isinstance(overlay, CanvasOverlay):
+            self._connect_canvas_overlay_events(overlay)
+            overlay.events.gridded.connect(self._update_viewer_overlays)
+            vispy_overlay.canvas_position_callback = (
+                self._defer_overlay_position_update
+            )
         self._overlay_to_visual.setdefault(overlay, []).append(vispy_overlay)
 
     def _remove_viewer_overlays(self) -> None:
         """Remove all viewer overlay visuals and disconnect their events."""
         for overlay in list(self._overlay_to_visual):
             if isinstance(overlay, CanvasOverlay):
+                self._disconnect_canvas_overlay_events(overlay)
                 overlay.events.gridded.disconnect(self._update_viewer_overlays)
             vispy_overlays = self._overlay_to_visual.pop(overlay)
             for vispy_overlay in vispy_overlays:
@@ -821,15 +847,13 @@ class VispyCanvas:
             else:
                 views = [self.view]
 
-            if isinstance(overlay, CanvasOverlay):
-                for view in views:
-                    self._add_viewer_overlay(overlay, view)
-                overlay.events.gridded.connect(self._update_viewer_overlays)
-            else:
-                for view in views:
-                    self._add_viewer_overlay(overlay, view.scene)
+            for view in views:
+                parent = (
+                    view if isinstance(overlay, CanvasOverlay) else view.scene
+                )
+                self._add_viewer_overlay(overlay, parent)
 
-        self._update_overlay_canvas_positions()
+        self._defer_overlay_position_update()
 
     def _add_layer_overlay(
         self, layer: Layer, overlay: Overlay, parent: Node
@@ -838,6 +862,11 @@ class VispyCanvas:
         vispy_overlay = create_vispy_overlay(
             overlay, layer=layer, parent=parent
         )
+        if isinstance(overlay, CanvasOverlay):
+            self._connect_canvas_overlay_events(overlay)
+            vispy_overlay.canvas_position_callback = (
+                self._defer_overlay_position_update
+            )
 
         self._layer_overlay_to_visual[layer][overlay] = vispy_overlay
 
@@ -845,6 +874,8 @@ class VispyCanvas:
         """Remove all layer overlay visuals and disconnect their events."""
         for overlay in list(self._layer_overlay_to_visual[layer]):
             vispy_overlay = self._layer_overlay_to_visual[layer].pop(overlay)
+            if isinstance(overlay, CanvasOverlay):
+                self._disconnect_canvas_overlay_events(overlay)
             vispy_overlay.close()
 
     def _update_layer_overlays(self, layer: Layer) -> None:
@@ -875,41 +906,122 @@ class VispyCanvas:
 
             self._add_layer_overlay(layer, overlay, parent)
 
-        self._update_overlay_canvas_positions()
+        self._defer_overlay_position_update()
 
-    def _get_ordered_visible_canvas_overlays(self):
-        # note that some canvas overlays do no use CanvasPosition, but are instead
-        # free-floating (such as the cursor overlay), so those are skipped
+    def _get_ordered_visible_canvas_overlays(
+        self,
+    ) -> Iterator[tuple[CanvasOverlay, VispyBaseOverlay, Node | None]]:
+        """
+        Iterator over visible canvas overlays by grid viewbox, in tiling order.
 
-        # first viewer overlays
-        for overlay, vispy_overlays in self._overlay_to_visual.items():
-            if (
+        Returns a tuple containing the overlay model, its matching visual, and
+        the index of the view in the grid where the overlay should be displayed.
+        The view `None` is special cased to refer to the base, non-gridded view.
+
+        Note that some canvas overlays do no use CanvasPosition, but are instead
+        free-floating (such as the cursor overlay), so those are skipped
+        """
+
+        def is_visible_tileable(overlay):
+            return (
                 overlay.visible
                 and isinstance(overlay, CanvasOverlay)
                 and overlay.position in list(CanvasPosition)
-            ):
-                yield overlay, vispy_overlays
+            )
 
-        # then layer overlays
-        for layer in self.viewer.layers:
-            for overlay, vispy_overlay in self._layer_overlay_to_visual.get(
-                layer, {}
-            ).items():
-                if (
-                    layer.visible
-                    and overlay.visible
-                    and isinstance(overlay, CanvasOverlay)
-                    and overlay.position in list(CanvasPosition)
-                ):
-                    yield overlay, [vispy_overlay]
+        def is_gridded(overlay):
+            return overlay.gridded and self.viewer.grid.enabled
+
+        # first the base view: non-gridded viewer overlays which appear
+        # "on top of" the main canvas
+        for overlay, vispy_overlays in self._overlay_to_visual.items():
+            if is_visible_tileable(overlay) and not is_gridded(overlay):
+                yield overlay, vispy_overlays[0], None
+
+        # then gridded viewer overlays and layer overlays, by viewbox, in order
+        for viewbox_idx, (_, layer_indices) in enumerate(
+            self.viewer.grid.iter_viewboxes(len(self.viewer.layers))
+        ):
+            if not layer_indices:
+                # last empty boxes of the grid
+                break
+
+            # if grid is disabled, this loop runs once and we put everything
+            # in the base (None) viewbox
+            view = viewbox_idx if self.viewer.grid.enabled else None
+
+            for overlay, vispy_overlays in self._overlay_to_visual.items():
+                if is_visible_tileable(overlay) and is_gridded(overlay):
+                    yield overlay, vispy_overlays[viewbox_idx], view
+
+            # layer overlays are always "gridded"
+            # (they always appear in the same viewbox as the layer itself)
+            for layer_idx in layer_indices:
+                layer = self.viewer.layers[layer_idx]
+                for (
+                    overlay,
+                    vispy_overlay,
+                ) in self._layer_overlay_to_visual.get(layer, {}).items():
+                    if layer.visible and is_visible_tileable(overlay):
+                        yield overlay, vispy_overlay, view
 
     def _update_overlay_canvas_positions(self, event=None):
+        # TODO: make settable
+        x_padding = y_padding = 10.0
+        x_offset_total = {}
+        y_offset_total = {}
         for (
-            _,
-            vispy_overlays,
+            overlay,
+            vispy_overlay,
+            view,
         ) in self._get_ordered_visible_canvas_overlays():
-            for vispy_overlay in vispy_overlays:
-                vispy_overlay._on_position_change()
+            # TODO: vertical vs horizontal tiling should be settable!
+            x_offset_total.setdefault(
+                view, dict.fromkeys(CanvasPosition, x_padding)
+            )
+            y_offset_total.setdefault(
+                view, dict.fromkeys(CanvasPosition, y_padding)
+            )
+
+            x_offset = x_offset_total[view][overlay.position]
+            y_offset = y_offset_total[view][overlay.position]
+
+            # add offset to the following overlays based on tiling direction
+            # these are currently hardcoded, so we just tile horizontally or
+            # vertically depending on which corner we're on
+            if overlay.position in ('top_right', 'bottom_left'):
+                x_offset_total[view][overlay.position] += (
+                    vispy_overlay.x_size + x_padding
+                )
+            else:
+                y_offset_total[view][overlay.position] += (
+                    vispy_overlay.y_size + y_padding
+                )
+
+            # position the overlay in the canvas
+            # if the overlay is in a grid viewbox, use the viewbox size
+            if view is None:
+                y_max, x_max = self.size
+            else:
+                x_max, y_max = self._current_viewbox_size
+            position = overlay.position
+
+            x = y = 0
+            if 'top' in position:
+                y = y_offset
+            elif 'bottom' in position:
+                y = y_max - vispy_overlay.y_size - y_offset
+
+            if 'left' in position:
+                x = x_offset
+            elif 'right' in position:
+                x = x_max - vispy_overlay.x_size - x_offset
+            elif 'center' in position:
+                x = x_max / 2 - vispy_overlay.x_size / 2
+
+            vispy_overlay.node.transform.translate = [x, y, 0, 0]
+
+        self._needs_overlay_position_update = False
 
     def _calculate_view_direction(
         self, event_pos: tuple[float, float]

--- a/src/napari/_vispy/overlays/base.py
+++ b/src/napari/_vispy/overlays/base.py
@@ -3,9 +3,7 @@ from typing import TYPE_CHECKING
 from vispy.visuals.transforms import MatrixTransform, STTransform
 
 from napari._vispy.utils.gl import BLENDING_MODES
-from napari.components._viewer_constants import CanvasPosition
 from napari.utils.events import disconnect_events
-from napari.utils.translations import trans
 
 if TYPE_CHECKING:
     from napari.layers import Layer
@@ -57,72 +55,26 @@ class VispyBaseOverlay:
 class VispyCanvasOverlay(VispyBaseOverlay):
     """
     Vispy overlay backend for overlays that live in canvas space.
+
+    NOTE: Subclasses should make sure to properly set their x_size and y_size
+    attribute when their size changes for proper tiling.
+
+    canvas_position_callback is set by the VispyCanvas object, and is responsible
+    to update the position of all canvas overlays whenever necessary
     """
 
     def __init__(self, *, overlay, node, parent=None) -> None:
         super().__init__(overlay=overlay, node=node, parent=parent)
-
-        # offsets and size are used to control fine positioning, and will depend
-        # on the subclass and visual that needs to be rendered
-        self.x_offset = 10.0
-        self.y_offset = 10.0
         self.x_size = 0.0
         self.y_size = 0.0
         self.node.transform = STTransform()
         self.overlay.events.position.connect(self._on_position_change)
+        self.canvas_position_callback = lambda: None
 
     def _on_position_change(self, event=None):
-        # subclasses should set sizes correctly and adjust offsets to get
-        # the optimal positioning
-        if self.node.parent is None:
-            return
-        x_max, y_max = list(self.node.parent.size)
-        position = self.overlay.position
-
-        if position == CanvasPosition.TOP_LEFT:
-            transform = [self.x_offset, self.y_offset, 0, 0]
-        elif position == CanvasPosition.TOP_CENTER:
-            transform = [x_max / 2 - self.x_size / 2, self.y_offset, 0, 0]
-        elif position == CanvasPosition.TOP_RIGHT:
-            transform = [
-                x_max - self.x_size - self.x_offset,
-                self.y_offset,
-                0,
-                0,
-            ]
-        elif position == CanvasPosition.BOTTOM_LEFT:
-            transform = [
-                self.x_offset,
-                y_max - self.y_size - self.y_offset,
-                0,
-                0,
-            ]
-        elif position == CanvasPosition.BOTTOM_CENTER:
-            transform = [
-                x_max / 2 - self.x_size / 2,
-                y_max - self.y_size - self.y_offset,
-                0,
-                0,
-            ]
-        elif position == CanvasPosition.BOTTOM_RIGHT:
-            transform = [
-                x_max - self.x_size - self.x_offset,
-                y_max - self.y_size - self.y_offset,
-                0,
-                0,
-            ]
-        else:
-            raise ValueError(
-                trans._(
-                    'Position {position} not recognized.',
-                    deferred=True,
-                    position=position,
-                )
-            )
-
-        self.node.transform.translate = transform
-        scale = abs(self.node.transform.scale[0])
-        self.node.transform.scale = [scale, 1, 1, 1]
+        # NOTE: when subclasses call this method, they should first ensure sizes
+        # (x_size, and y_size) are set correctly
+        self.canvas_position_callback()
 
     def reset(self) -> None:
         super().reset()

--- a/src/napari/_vispy/overlays/scale_bar.py
+++ b/src/napari/_vispy/overlays/scale_bar.py
@@ -8,6 +8,7 @@ import pint
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
 from napari._vispy.visuals.scale_bar import ScaleBar
 from napari.utils._units import PREFERRED_VALUES
+from napari.utils.color import ColorValue
 from napari.utils.colormaps.standardize_color import transform_color
 from napari.utils.theme import get_theme
 
@@ -17,37 +18,35 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
 
     def __init__(self, *, viewer, overlay, parent=None) -> None:
         self._target_length = 150.0
+        self._current_length = 150.0
+        self._current_color = (1, 1, 1, 1)
         self._scale = 1
-        self._unit: pint.Unit
+        self._unit = pint.Quantity('1 pixel')
 
         super().__init__(
             node=ScaleBar(), viewer=viewer, overlay=overlay, parent=parent
         )
-        self.x_size = 150.0  # will be updated on zoom anyways
-        # need to change from defaults because the anchor is in the center
-        self.y_offset = 7.0  # padding from the bottom edge
-        self.y_size = 18.0  # half the box height
 
         self.overlay.events.box.connect(self._on_box_change)
-        self.overlay.events.box_color.connect(self._on_data_change)
-        self.overlay.events.color.connect(self._on_data_change)
-        self.overlay.events.colored.connect(self._on_data_change)
-        self.overlay.events.font_size.connect(self._on_text_change)
-        self.overlay.events.ticks.connect(self._on_data_change)
+        self.overlay.events.box_color.connect(self._on_rendering_change)
+        self.overlay.events.color.connect(self._on_rendering_change)
+        self.overlay.events.colored.connect(self._on_rendering_change)
+        self.overlay.events.font_size.connect(self._on_font_size_change)
+        self.overlay.events.ticks.connect(self._on_rendering_change)
         self.overlay.events.unit.connect(self._on_unit_change)
-        self.overlay.events.length.connect(self._on_length_change)
+        self.overlay.events.length.connect(self._on_size_or_zoom_change)
 
-        self.viewer.events.theme.connect(self._on_data_change)
-        self.viewer.camera.events.zoom.connect(self._on_zoom_change)
+        self.viewer.events.theme.connect(self._on_rendering_change)
+        self.viewer.camera.events.zoom.connect(self._on_size_or_zoom_change)
 
         self.reset()
 
     def _on_unit_change(self):
         self._unit = pint.get_application_registry()(self.overlay.unit)
-        self._on_zoom_change(force=True)
+        self._on_size_or_zoom_change(force=True)
 
-    def _on_length_change(self):
-        self._on_zoom_change(force=True)
+    def _on_font_size_change(self):
+        self._on_size_or_zoom_change(force=True)
 
     def _calculate_best_length(
         self, desired_length: float
@@ -102,8 +101,8 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
         new_quantity = new_value * new_quantity.units
         return new_length, new_quantity
 
-    def _on_zoom_change(self, *, force: bool = False):
-        """Update axes length based on zoom scale."""
+    def _on_size_or_zoom_change(self, *, force: bool = False):
+        """Update length based on scale bar size and zoom."""
 
         # If scale has not changed, do not redraw
         scale = 1 / self.viewer.camera.zoom
@@ -129,16 +128,15 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                 target_world_pixels_rounded / scale_canvas2world
             )
 
-        scale = target_canvas_pixels
+        self._current_length = target_canvas_pixels
 
         # Update scalebar and text
-        self.node.transform.scale = [scale, 1, 1, 1]
         self.node.text.text = f'{new_dim:g~#P}'
-        self.x_size = scale  # needed to offset properly
-        super()._on_position_change()
+        self._on_rendering_change()
+        self._on_position_change()
 
-    def _on_data_change(self):
-        """Change color and data of scale bar and box."""
+    def _get_colors(self) -> tuple[ColorValue, ColorValue]:
+        """Get the foreground and background colors for the visual."""
         color = self.overlay.color
         box_color = self.overlay.box_color
 
@@ -165,52 +163,32 @@ class VispyScaleBarOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
                 color = np.subtract(1, background_color)
                 color[-1] = background_color[-1]
 
-        self.node.set_data(color, self.overlay.ticks)
+        return color, box_color
+
+    def _on_rendering_change(self):
+        """Change color and other rendering features of scale bar and box."""
+        color, box_color = self._get_colors()
+
+        width, height = self.node.set_data(
+            length=self._current_length,
+            color=color,
+            ticks=self.overlay.ticks,
+            font_size=self.overlay.font_size,
+        )
         self.node.box.color = box_color
+
+        self.x_size = width
+        self.y_size = height
 
     def _on_box_change(self):
         self.node.box.visible = self.overlay.box
 
-    def _on_text_change(self):
-        """Update text information"""
-        # update the dpi scale factor to account for screen dpi
-        # because vispy scales pixel height of text by screen dpi
-        if self.node.text.transforms.dpi:
-            # use 96 as the napari reference dpi for historical reasons
-            dpi_scale_factor = 96 / self.node.text.transforms.dpi
-        else:
-            dpi_scale_factor = 1
-
-        self.node.text.font_size = self.overlay.font_size * dpi_scale_factor
-        # changing the fox size changes the box height and positioning in it
-        self.node._update_layout(font_size=self.overlay.font_size)
-
-        # positioning in the box uses the center of the box
-        # need to adjust the y_size to be half the size of the current box height
-        self.y_size = self.node.box.height / 2
-
-        self._on_position_change()
-
-    def _on_position_change(self, event=None):
-        # prevent the text from being cut off by shifting down
-        if 'top' in self.overlay.position:
-            # adjust the positioning to account for the box height
-            # 7 is base value for the default 10 font size
-            self.y_offset = 7 + self.y_size
-        else:
-            # ensure if switching from top to bottom, the offset is reset
-            self.y_offset = 7
-        super()._on_position_change()
-
     def _on_visible_change(self):
         # ensure that dpi is updated when the scale bar is visible
-        self._on_text_change()
+        self._on_size_or_zoom_change()
         return super()._on_visible_change()
 
     def reset(self):
         super().reset()
-        self._on_unit_change()
-        self._on_data_change()
         self._on_box_change()
-        self._on_text_change()
-        self._on_length_change()
+        self._on_unit_change()

--- a/src/napari/_vispy/overlays/text.py
+++ b/src/napari/_vispy/overlays/text.py
@@ -1,6 +1,5 @@
-from vispy.scene.visuals import Text
-
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispyCanvasOverlay
+from napari._vispy.visuals.text import Text
 from napari.components._viewer_constants import CanvasPosition
 
 
@@ -15,28 +14,31 @@ class VispyTextOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             parent=parent,
         )
 
-        self.node.font_size = self.overlay.font_size
-        self.node.anchors = ('left', 'top')
+        self.node.anchors = ('left', 'bottom')
 
         self.overlay.events.text.connect(self._on_text_change)
         self.overlay.events.color.connect(self._on_color_change)
-        self.overlay.events.font_size.connect(self._on_font_size_change)
+        self.overlay.events.font_size.connect(self._on_position_change)
 
         self.reset()
 
     def _on_text_change(self):
         self.node.text = self.overlay.text
+        self._on_position_change()
+
+    def _on_visible_change(self):
+        # ensure that dpi is updated when the scale bar is visible
+        # this does not need to run _on_position_change because visibility
+        # is already connected to the canvas callback by the canvas itself
+        self._on_text_change()
+        return super()._on_visible_change()
 
     def _on_color_change(self):
         self.node.color = self.overlay.color
 
-    def _on_font_size_change(self):
-        self.node.font_size = self.overlay.font_size
-
     def _on_position_change(self, event=None):
-        super()._on_position_change()
         position = self.overlay.position
-
+        anchors = ('left', 'bottom')
         if position == CanvasPosition.TOP_LEFT:
             anchors = ('left', 'bottom')
         elif position == CanvasPosition.TOP_RIGHT:
@@ -51,9 +53,26 @@ class VispyTextOverlay(ViewerOverlayMixin, VispyCanvasOverlay):
             anchors = ('center', 'top')
 
         self.node.anchors = anchors
+        self.node.font_size = self.overlay.font_size
+
+        self.x_size, self.y_size = self.node.get_width_height()
+
+        # depending on the canvas position, we need to change the position of the anchor itself
+        # to ensure the text aligns properly e.g. left when on the left, and right when on the right
+        x = y = 0.0
+        if anchors[0] == 'right':
+            x = self.x_size
+        elif anchors[0] == 'center':
+            x = self.x_size / 2
+
+        if anchors[1] == 'top':
+            y = self.y_size
+
+        self.node.pos = (x, y)
+
+        super()._on_position_change()
 
     def reset(self):
         super().reset()
         self._on_text_change()
         self._on_color_change()
-        self._on_font_size_change()

--- a/src/napari/_vispy/utils/text.py
+++ b/src/napari/_vispy/utils/text.py
@@ -1,3 +1,5 @@
+from typing import no_type_check
+
 import numpy as np
 from vispy.scene.visuals import Text
 
@@ -71,3 +73,165 @@ def _has_visible_text(layer: Points | Shapes) -> bool:
     ):
         return False
     return len(layer._indices_view) != 0
+
+
+def get_text_width_height(text: Text) -> tuple[float, float]:
+    """Get the width and height of a vispy text visual in screen pixels.
+
+    If display scaling is not 1 (e.g. hidpi), this is already accounted for
+    by vispy.
+    """
+    if isinstance(text.text, str):
+        strings = [text.text]
+    elif isinstance(text.text, list):
+        strings = text.text
+    else:
+        raise TypeError('Text should either be a string or a list of strings')
+
+    top_left_corners = []
+    bottom_right_corners = []
+    for string in strings:
+        if string == '':
+            continue
+
+        # this is a private vispy function that calculates the Vertex Buffer Object
+        # for the text to be sent to the shaders. This normallly only happens on
+        # the fly when rendering, but we need it here because it allows us to
+        # calculate the bounding box of the text as it would be when rendered
+        buffer = _text_to_vbo(
+            string, text._font, *text._anchors, text._font._lowres_size
+        )
+
+        pos = buffer['a_position']
+        top_left_corners.append(pos.min(axis=0))
+        bottom_right_corners.append(pos.max(axis=0))
+
+    top_left = np.min(top_left_corners, axis=0) if top_left_corners else (0, 0)
+    bottom_right = (
+        np.max(bottom_right_corners, axis=0)
+        if bottom_right_corners
+        else (0, 0)
+    )
+
+    # these magic numbers (1.2 and 1.3) are from trial and error
+    return (bottom_right[0] - top_left[0]) * text.font_size, (
+        bottom_right[1] - top_left[1]
+    ) * text.font_size
+
+
+# vendored from vispy/visuals/text/text.py, but removing all lines referring to context flushing,
+# canvas and viewport which cause issues. We only need to calculate sizes anyways.
+@no_type_check
+def _text_to_vbo(text, font, anchor_x, anchor_y, lowres_size):
+    """Convert text characters to VBO"""
+    text_vtype = np.dtype(
+        [('a_position', np.float32, 2), ('a_texcoord', np.float32, 2)]
+    )
+    vertices = np.zeros(len(text) * 4, dtype=text_vtype)
+    prev = None
+    width = height = ascender = descender = 0
+    ratio, slop = 1.0 / font.ratio, font.slop
+    x_off = -slop
+    # Need to store the original viewport, because the font[char] will
+    # trigger SDF rendering, which changes our viewport
+    # todo: get rid of call to glGetParameter!
+
+    # Also analyse chars with large ascender and descender, otherwise the
+    # vertical alignment can be very inconsistent
+    for char in 'hy':
+        glyph = font[char]
+        y0 = glyph['offset'][1] * ratio + slop
+        y1 = y0 - glyph['size'][1]
+        ascender = max(ascender, y0 - slop)
+        descender = min(descender, y1 + slop)
+        height = max(height, glyph['size'][1] - 2 * slop)
+
+    # Get/set the fonts whitespace length and line height (size of this ok?)
+    glyph = font[' ']
+    spacewidth = glyph['advance'] * ratio
+    lineheight = height * 1.5
+
+    # Added escape sequences characters: {unicode:offset,...}
+    #   ord('\a') = 7
+    #   ord('\b') = 8
+    #   ord('\f') = 12
+    #   ord('\n') = 10  => linebreak
+    #   ord('\r') = 13
+    #   ord('\t') = 9   => tab, set equal 4 whitespaces?
+    #   ord('\v') = 11  => vertical tab, set equal 4 linebreaks?
+    # If text coordinate offset > 0 -> it applies to x-direction
+    # If text coordinate offset < 0 -> it applies to y-direction
+    esc_seq = {7: 0, 8: 0, 9: -4, 10: 1, 11: 4, 12: 0, 13: 0}
+
+    # Keep track of y_offset to set lines at right position
+    y_offset = 0
+
+    # When a line break occur, record the vertices index value
+    vi_marker = 0
+    ii_offset = 0  # Offset since certain characters won't be drawn
+
+    # The running tracker of characters vertex index
+    vi = 0
+
+    for ii, char in enumerate(text):
+        if ord(char) in esc_seq:
+            if esc_seq[ord(char)] < 0:
+                # Add offset in x-direction
+                x_off += abs(esc_seq[ord(char)]) * spacewidth
+                width += abs(esc_seq[ord(char)]) * spacewidth
+            elif esc_seq[ord(char)] > 0:
+                # Add offset in y-direction and reset things in x-direction
+                dx = dy = 0
+                if anchor_x == 'right':
+                    dx = -width
+                elif anchor_x == 'center':
+                    dx = -width / 2.0
+                vertices['a_position'][vi_marker : vi + 4] += (dx, dy)
+                vi_marker = vi + 4
+                ii_offset -= 1
+                # Reset variables that affects x-direction positioning
+                x_off = -slop
+                width = 0
+                # Add offset in y-direction
+                y_offset += esc_seq[ord(char)] * lineheight
+        else:
+            # For ordinary characters, normal procedure
+            glyph = font[char]
+            kerning = glyph['kerning'].get(prev, 0.0) * ratio
+            x0 = x_off + glyph['offset'][0] * ratio + kerning
+            y0 = glyph['offset'][1] * ratio + slop - y_offset
+            x1 = x0 + glyph['size'][0]
+            y1 = y0 - glyph['size'][1]
+            u0, v0, u1, v1 = glyph['texcoords']
+            position = [[x0, y0], [x0, y1], [x1, y1], [x1, y0]]
+            texcoords = [[u0, v0], [u0, v1], [u1, v1], [u1, v0]]
+            vi = (ii + ii_offset) * 4
+            vertices['a_position'][vi : vi + 4] = position
+            vertices['a_texcoord'][vi : vi + 4] = texcoords
+            x_move = glyph['advance'] * ratio + kerning
+            x_off += x_move
+            ascender = max(ascender, y0 - slop)
+            descender = min(descender, y1 + slop)
+            width += x_move
+            height = max(height, glyph['size'][1] - 2 * slop)
+            prev = char
+
+    dx = dy = 0
+    if anchor_y == 'top':
+        dy = -descender
+    elif anchor_y in ('center', 'middle'):
+        dy = (-descender - ascender) / 2
+    elif anchor_y == 'bottom':
+        dy = -ascender
+    if anchor_x == 'right':
+        dx = -width
+    elif anchor_x == 'center':
+        dx = -width / 2.0
+
+    # If any linebreaks occured in text, we only want to translate characters
+    # in the last line in text (those after the vi_marker)
+    vertices['a_position'][0:vi_marker] += (0, dy)
+    vertices['a_position'][vi_marker:] += (dx, dy)
+    vertices['a_position'] /= lowres_size
+
+    return vertices

--- a/src/napari/_vispy/visuals/text.py
+++ b/src/napari/_vispy/visuals/text.py
@@ -1,0 +1,26 @@
+from vispy.scene.visuals import Text as BaseText
+
+from napari._vispy.utils.text import get_text_width_height
+
+
+class Text(BaseText):
+    def get_width_height(self) -> tuple[float, float]:
+        width, height = get_text_width_height(self)
+        # width is not quite right for some reason... magic number here we go
+        return width * self.dpi_ratio * 1.2, height * self.dpi_ratio
+
+    @property
+    def font_size(self) -> float:
+        return self._font_size
+
+    @font_size.setter
+    def font_size(self, size: float) -> None:
+        adjusted_font_size = size / self.dpi_ratio
+        self._font_size = max(0.0, adjusted_font_size)
+        self.update()
+
+    @property
+    def dpi_ratio(self) -> float:
+        # adjust for dpi: 72 is the "base dpi" around which font sizes are defined
+        # TODO: but for some reason 96 seems to give the correct ratio for me?
+        return (self.transforms.dpi or 96) / 96

--- a/src/napari/components/grid.py
+++ b/src/napari/components/grid.py
@@ -142,9 +142,6 @@ class GridCanvas(EventedModel):
         indices : tuple of int
             Position of current layer in layer list.
         """
-        if not self.enabled:
-            return ()
-
         return tuple(
             i for i in range(nlayers) if self.position(i, nlayers) == position
         )

--- a/src/napari/components/overlays/scale_bar.py
+++ b/src/napari/components/overlays/scale_bar.py
@@ -31,8 +31,8 @@ class ScaleBarOverlay(CanvasOverlay):
         Background box color.
         See ``ColorValue.validate`` for supported values.
     unit : Optional[str]
-        Unit to be used by the scale bar. The value can be set
-        to `None` to display no units.
+        Unit to be used by the scale bar, equivalent to 1 pixel. Can be a quantity
+        such as "10 nm". The value can be set to `None` to display no units.
     length : Optional[float]
         Fixed length of the scale bar in physical units. If set to `None`,
         it is determined automatically based on zoom level.


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7836

# References and relevant issues
Part of the work in #7832.
Depends on #7835.
Diff relative to #7835: https://github.com/brisvag/napari/compare/refactor/overlays...brisvag:napari:feature/tiling-overlays2

# Description

Canvas overlays can be positioned on the canvas using a limited set of positions (`top_left`, `bottom_right` and so on).
Currently, if two overlays end up in the same place, they simply overlap.

This PR introduces tiling for canvas overlays by looping through all canva...